### PR TITLE
fix: use empty array when no default options

### DIFF
--- a/src/components/edit-field-form.tsx
+++ b/src/components/edit-field-form.tsx
@@ -80,7 +80,7 @@ export const EditFieldForm = ({
       required: fieldData?.required || false,
       type: fieldData?.type || undefined,
       formId: fieldData?.formId || formId,
-      options: fieldData?.options?.split(",") || [],
+      options: fieldData?.options?.length ? fieldData.options.split(",") : [],
     },
   })
 


### PR DESCRIPTION
Issue:
The default value for `options` was set to `['']` when there are no options. This is not valid value for the validation `.min(1)`.

Fix:
Add check and use empty array as default when there is no options array.

Closes #15 